### PR TITLE
Add user friendly setup script instead of list of instructions to follow

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,14 @@ mingw-w64-x86_64-libunistring
 xgameruntime.dll.threading
 ```
 
-## For Minecraft
+## For games using `XCurl.dll`
 
-**NOTES**: OpenSSL only works in protonified wine builds. You can use GDK-Proton (in the Releases section of this Repository) if you are not inclined to build proton from scratch yourself.   
+**NOTES**: OpenSSL only works in protonified wine builds. You can use GDK-Proton (in the Releases section of this Repository) if you are not inclined to build proton from scratch yourself.
 
-To get online functionality working, you will need to follow this guide, exactly as mentioned:  
-1) Download [mingw-w64-x86_64-curl](https://mirror.msys2.org/mingw/mingw64/mingw-w64-x86_64-curl-8.17.0-1-any.pkg.tar.zst) and extract it
-2) In the extracted folder, rename `mingw64/bin/libcurl-4.dll` to `XCurl.dll`.
-3) Copy it to Minecraft's binaries, replacing `XCurl.dll`.
-4) Obtain SSL certificates from https://curl.se/ca/cacert.pem and rename this file to `ca-bundle.crt`
-5) **IMPORTANT**, Create a folder named `etc`, and under that folder create another folder named `ssl`, and under the `ssl` folder, create a `certs` folder.
-6) **IMPORTANT**, Move `ca-bundle.crt` to this new `certs` folder.
-if you've done everything correctly, your file structure should look a bit like the following image:
-<img width="772" height="240" alt="image" src="https://github.com/user-attachments/assets/d6e27fc3-ecb4-46be-9448-800535bbc1b6" />
+To get online functionality working, use the `replace-xcurl` script in this repo, syntax:
 
-Now if you launch the game, the game should be able to phone home and get online. Just keep in mind that `XUser` is still not implemented so no Microsoft Account login yet.   
+```sh
+./replace-xcurl [path/to/game]
+```
+
+Now if you launch the game, the game should be able to phone home and get online. Just keep in mind that `XUser` is still not implemented so no Microsoft Account login yet.

--- a/replace-xcurl
+++ b/replace-xcurl
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+dir=${1:-.}
+pushd $dir
+
+# Backup original XCurl.dll
+mv "./XCurl.dll" "./XCurl.dll~"
+
+# Download required mingw64 dlls
+brotli=('brotli-1.1.0-2' 'libbrotlicommon libbrotlidec')
+curl=('curl-8.20.0-1' 'libcurl-4')
+gettext=('gettext-runtime-1.0-1' 'libintl-8')
+libiconv=('libiconv-1.19-1' 'libiconv-2')
+libidn2=('libidn2-2.3.8-4' 'libidn2-0')
+libpsl=('libpsl-0.21.5-3' 'libpsl-5')
+libssh2=('libssh2-1.11.1-2' 'libssh2-1')
+libunistring=('libunistring-1.2-1' 'libunistring-5')
+nghttp2=('nghttp2-1.69.0-1' 'libnghttp2-14')
+nghttp3=('nghttp3-1.9.0-1' 'libnghttp3-9')
+ngtcp2=('ngtcp2-1.22.1-1' 'libngtcp2-16 libngtcp2_crypto_ossl-0')
+openssl=('openssl-3.6.2-2' 'libcrypto-3-x64 libssl-3-x64')
+zlib=('zlib-1.3.2-2' 'zlib1')
+zstd=('zstd-1.5.7-2' 'libzstd')
+
+packages=(brotli curl gettext libiconv libidn2 libpsl libssh2 libunistring nghttp2 nghttp3 ngtcp2 openssl zlib zstd)
+
+declare -n package
+for package in ${packages[@]}; do
+    curl "https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-${package[0]}-any.pkg.tar.zst" -o - | tar --zstd -x $(echo ${package[1]} | xargs printf -- 'mingw64/bin/%s.dll ')--transform "s/mingw64\/bin\///"
+done
+
+# Rename curl dll
+mv "libcurl-4.dll" "XCurl.dll"
+
+# Download required ssl certificates
+mkdir -p "../etc/ssl/certs"
+curl 'https://curl.se/ca/cacert.pem' -o "../etc/ssl/certs/ca-bundle.crt"
+
+popd


### PR DESCRIPTION
Doesn't currently include fetching xgameruntime.dll.threading from store api, I can include that if you wish, I just tried to make the script general purpose instead of GDK/minecraft specific.

Also the script dumps the dlls into the game directory, since we are changing XCurl.dll from that directory anyways, I could adjust that to take a `PROTONPATH` instead.